### PR TITLE
Fix the mustache template regex

### DIFF
--- a/src/patch/faker.ts
+++ b/src/patch/faker.ts
@@ -3,7 +3,7 @@ import { IFaker } from "faker";
 /**
  * Compiled regular expression to match mustache expressions.
  */
-const ANY_MUSTACHES = /{{([^(]*?)(?:\(([^]*?)\)\s*}}|}})/g;
+const ANY_MUSTACHES = /\{\{\s*(?:([^(]+?)(?:\(([^)]*)\))?)?\s*\}\}/g;
 
 /**
  * Creates a new implementation of the `Faker.fake` method from the _Faker.js_


### PR DESCRIPTION
- fix character-class typo: `[^]` -> `[^)]`
- ensure the name is non-empty: `[^(]*` -> `[^(]+`
- allow leading/trailing spaces e.g. `{{ name.firstName }}`
- escape special characters: `{{` -> `\{\{`